### PR TITLE
Lifecicle pitr

### DIFF
--- a/modules/azure-flexible-server-postgresql/README.md
+++ b/modules/azure-flexible-server-postgresql/README.md
@@ -94,6 +94,10 @@ dns:
     resource_group: test-modulo
 ```
 
+## PITR creation explanation
+
+The creation of a server from a PITR will create a new server. If the source is different and is deleted, the new server will not be affected, however, you will have to change the `server_creation.mode` to `Default` after its creation so that it is not tried to restore again and thus be able to apply a `terraform plan` or` terraform apply` without trying to restore again.
+
 ## Get list of PiTRs backups
 
 ```yaml

--- a/modules/azure-flexible-server-postgresql/flexible_server.tf
+++ b/modules/azure-flexible-server-postgresql/flexible_server.tf
@@ -36,7 +36,10 @@ resource "azurerm_postgresql_flexible_server" "postgresql_flexible_server" {
   ]
   lifecycle {
     ignore_changes = [
-      version
+      version,
+      create_mode,
+      point_in_time_restore_time_in_utc,
+      source_server_id
     ]
   }
 }


### PR DESCRIPTION
The creation of a server from a PITR will create a new server. If the source is different and is deleted, the new server will not be affected, however, you will have to change the `server_creation.mode` to `Default` after its creation so that it is not tried to restore again and thus be able to apply a `terraform plan` or` terraform apply` without trying to restore again.