### PR TITLE
Update alb policy to versions 2.7.0 aws-load-balancer-controller

### DIFF
--- a/modules/aws-eks/iam_alb.tf
+++ b/modules/aws-eks/iam_alb.tf
@@ -88,7 +88,8 @@ resource "aws_iam_policy" "iam_policy_alb" {
           "elasticloadbalancing:DescribeTargetGroups",
           "elasticloadbalancing:DescribeTargetGroupAttributes",
           "elasticloadbalancing:DescribeTargetHealth",
-          "elasticloadbalancing:DescribeTags"
+          "elasticloadbalancing:DescribeTags",
+	  "elasticloadbalancing:DescribeTrustStores"
         ],
         "Resource" : "*"
       },


### PR DESCRIPTION
Update alb policy to versions 2.7.0 aws-load-balancer-controller

 In aws-load-balancer-controller version 2.7.0 they recommend adding the `elasticloadbalancing:DescribeTrustStores` permission to the policy.

- Changelog: https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/tag/v2.7.0  