### PR TITLE
fix: avoid validations

### DIFF
--- a/modules/azure-flexible-server-postgresql/README.md
+++ b/modules/azure-flexible-server-postgresql/README.md
@@ -77,7 +77,6 @@ password:
   key_vault_name: test-tfm-prefapp2
   key_vault_resource_group: test-modulo
   key_vault_secret_name: pg-pass2
-  create: true
 
 resource_group:
   name: test-modulo
@@ -105,7 +104,7 @@ The creation of a server from a PITR will create a new server. If the source is 
 az postgres flexible-server backup list --resource-group test-modulo --name mi-server
 ```
 
-## Optional Password creation
+## Password creation
 
 Now it suffises to pass a key vault , a resource group and a key name to have a random password created, inserted as a secret in the KV and as the pass of the server. 
 
@@ -114,15 +113,6 @@ password:
   key_vault_name: test-tfm-prefapp
   key_vault_resource_group: test-modulo
   key_vault_secret_name: pg-pass
-  create: true
 ```
 
-If the password is to be supplied not created by the module:
-
-```yaml
-password:
-  key_vault_name: test-tfm-prefapp
-  key_vault_resource_group: test-modulo
-  key_vault_secret_name: pg-pass
-  create: false
-```
+If the password exists it will no produce any changes, because it's vinculated to the `random_password` resource

--- a/modules/azure-flexible-server-postgresql/flexible_server.tf
+++ b/modules/azure-flexible-server-postgresql/flexible_server.tf
@@ -26,7 +26,7 @@ resource "azurerm_postgresql_flexible_server" "postgresql_flexible_server" {
     start_minute = local.data.maintainance_window.start_minute
   }
   administrator_login    = local.data.administrator_login
-  administrator_password = local.data.password.create ? random_password.password[0].result : null
+  administrator_password = azurerm_key_vault_secret.password_create.value
   zone                   = lookup(local.data.server, "zone", null)
   storage_mb             = local.data.server.disk_size
   sku_name               = local.data.server.sku_name

--- a/modules/azure-flexible-server-postgresql/key_vault_secret.tf
+++ b/modules/azure-flexible-server-postgresql/key_vault_secret.tf
@@ -1,32 +1,23 @@
-# We only generate the password if necessary
-resource "random_password" "password" {
-  count   = local.data.password.create ? 1 : 0
-  length  = 20
-  special = true
-}
-
-# We only upload the password if necessary
-# Once created we ignore it
-resource "azurerm_key_vault_secret" "password_create" {
-  count        = local.data.password.create ? 1 : 0
-  key_vault_id = data.azurerm_key_vault.key_vault.id
-  name         = local.data.password.key_vault_secret_name
-  value        = random_password.password[0].result ? random_password.password[0].result : null
-  lifecycle {
-    ignore_changes = [value]
-  }
-}
-
-# Checkers and data access
+# Data source to get the Key Vault details
 data "azurerm_key_vault" "key_vault" {
   name                = local.data.password.key_vault_name
   resource_group_name = local.data.password.key_vault_resource_group
 }
 
-data "azurerm_key_vault_secret" "password" {
-  name         = local.data.password.key_vault_secret_name
+# Always create the random password (even if it may not be used)
+resource "random_password" "password" {
+  length  = 20
+  special = true
+}
+
+# Create the Key Vault secret
+resource "azurerm_key_vault_secret" "password_create" {
   key_vault_id = data.azurerm_key_vault.key_vault.id
-  depends_on = [
-    azurerm_key_vault_secret.password_create
-  ]
+  name         = local.data.password.key_vault_secret_name
+  value        = random_password.password.result
+  depends_on = [ random_password.password ]
+  lifecycle {
+    # Ignore changes to the secret's value to prevent overwriting it after the initial creation
+    ignore_changes = [value]
+  }
 }


### PR DESCRIPTION
# Description

A data resource is not made to validate its existence, so the previous concepts of validating a secret based on the value queried in a data are not coherent to Terraform principles.

We tried to face the issue in a different way, reevaluating our concepts, so the code remains like this:

- Always create a password for an admin
  - That's because there's always a situation that needs admin access from our side, like managing users, permissions...
  - It serves another purpose, as having a key to query for script automation
- Upload the secret to the vault
  - As commented previously, we can use this secret for automation, stored in an infra keyvault
  - With the secrets in a vault, there's no need to manage resources from outside the Azure ecosystem
- Query the secret from the `azurerm_key_vault_secret` resource
  - This way allows us to avoid the chicken/egg dilemma. Which one goes first, the secret or the validation of the secret existence itself?
  - We avoid the error for query null data values, that break terraform execution
 - Rearrange resource dependencies and simplify management