### PR TITLE
Add more AKS module outputs

### DIFF
--- a/modules/azure-aks/outputs.tf
+++ b/modules/azure-aks/outputs.tf
@@ -24,3 +24,31 @@ output "outbound_ip_address" {
 output "cluster_issuer" {
   value = module.aks.oidc_issuer_url
 }
+
+output "oidc_issuer_url" {
+  value = module.aks.oidc_issuer_url
+}
+
+output "node_resource_group" {
+  value = module.aks.node_resource_group
+}
+
+output "network_profile" {
+  value = module.aks.network_profile
+}
+
+output "kubelet_identity" {
+  value = module.aks.kubelet_identity
+}
+
+output "host" {
+  value = module.aks.host
+}
+
+output "cluster_identity" {
+  value = module.aks.cluster_identity
+}
+
+output "cluster_fqdn" {
+  value = module.aks.cluster_fqdn
+}


### PR DESCRIPTION
Add netx outputs:
- oidc_issuer_url
- node_resource_group
- network_profile
- kubelet_identity
- host
- cluster_identity
- cluster_fqdn
