### PR TITLE
fix: modify defaults create_iam_role and iam_role_arn

### DIFF
--- a/modules/aws-eks/README.md
+++ b/modules/aws-eks/README.md
@@ -153,14 +153,14 @@ The module is organized with the following directory and file structure:
 | <a name="input_cluster_encryption_config"></a> [cluster\_encryption\_config](#input\_cluster\_encryption\_config) | Cluster encryption config | `any` | `{}` | no |
 | <a name="input_cluster_endpoint_private_access"></a> [cluster\_endpoint\_private\_access](#input\_cluster\_endpoint\_private\_access) | Indicates whether or not the Amazon EKS private API server endpoint is enabled. Default is true. | `bool` | `true` | no |
 | <a name="input_cluster_endpoint_public_access"></a> [cluster\_endpoint\_public\_access](#input\_cluster\_endpoint\_public\_access) | Indicates whether or not the Amazon EKS public API server endpoint is enabled. Default is false. | `bool` | `false` | no |
-| <a name="input_cluster_iam_role_arn"></a> [cluster\_iam\_role\_arn](#input\_cluster\_iam\_role\_arn) | n/a | `string` | n/a | yes |
+| <a name="input_cluster_iam_role_arn"></a> [cluster\_iam\_role\_arn](#input\_cluster\_iam\_role\_arn) | n/a | `string` | `null` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | n/a | `string` | n/a | yes |
 | <a name="input_cluster_security_group_id"></a> [cluster\_security\_group\_id](#input\_cluster\_security\_group\_id) | n/a | `string` | n/a | yes |
 | <a name="input_cluster_tags"></a> [cluster\_tags](#input\_cluster\_tags) | Tags to apply to the EKS cluster | `map(string)` | `{}` | no |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | n/a | `string` | n/a | yes |
 | <a name="input_create_alb_ingress_iam"></a> [create\_alb\_ingress\_iam](#input\_create\_alb\_ingress\_iam) | Create IAM resources for alb-ingress | `bool` | `false` | no |
 | <a name="input_create_cloudwatch_iam"></a> [create\_cloudwatch\_iam](#input\_create\_cloudwatch\_iam) | Create IAM resources for cloudwatch | `bool` | `false` | no |
-| <a name="input_create_cluster_iam_role"></a> [create\_cluster\_iam\_role](#input\_create\_cluster\_iam\_role) | Create IAM role for cluster | `bool` | `false` | no |
+| <a name="input_create_cluster_iam_role"></a> [create\_cluster\_iam\_role](#input\_create\_cluster\_iam\_role) | Create IAM role for cluster | `bool` | `true` | no |
 | <a name="input_create_cluster_security_group"></a> [create\_cluster\_security\_group](#input\_create\_cluster\_security\_group) | Create cluster security group | `bool` | `true` | no |
 | <a name="input_create_ebs_driver_iam"></a> [create\_ebs\_driver\_iam](#input\_create\_ebs\_driver\_iam) | Create IAM resources for ebs-driver | `bool` | `true` | no |
 | <a name="input_create_efs_driver_iam"></a> [create\_efs\_driver\_iam](#input\_create\_efs\_driver\_iam) | Create IAM resources for efs-driver | `bool` | `false` | no |

--- a/modules/aws-eks/variables.tf
+++ b/modules/aws-eks/variables.tf
@@ -33,6 +33,8 @@ variable "cluster_iam_role_arn" {
 
   type = string
 
+  default = null
+
 }
 
 
@@ -58,7 +60,7 @@ variable "create_cluster_iam_role" {
 
   type = bool
 
-  default = false
+  default = true
 
 }
 


### PR DESCRIPTION
Now the `create_cluster_iam_role` field is an optional field with default value `false`
https://github.com/prefapp/tfm/blob/aws-eks-v0.4.0/modules/aws-eks/variables.tf#L55-L63

Now the `cluster_iam_role_arn` field is a required field
https://github.com/prefapp/tfm/blob/aws-eks-v0.4.0/modules/aws-eks/variables.tf#L32-L36

The fix is ​​to treat them the same as the official aws eks module
https://github.com/terraform-aws-modules/terraform-aws-eks/blob/v20.33.1/variables.tf#L448-L458