### PR TITLE
fix: avoid destroy of resource group previously created

### DIFF
--- a/modules/azure-resource-group/resource_groups.tf
+++ b/modules/azure-resource-group/resource_groups.tf
@@ -4,3 +4,8 @@ resource "azurerm_resource_group" "this" {
   location = var.location
   tags     = var.tags != null ? var.tags : {}
 }
+
+moved {
+  from = azurerm_resource_group.resorce_group
+  to   = azurerm_resource_group.this
+}

--- a/modules/azure-resource-group/variables.tf
+++ b/modules/azure-resource-group/variables.tf
@@ -1,20 +1,20 @@
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group#name
 variable "name" {
-  type    = string
-  default = ""
+  type        = string
+  default     = ""
   description = "(Required) The Name which should be used for this Resource Group. Changing this forces a new Resource Group to be created."
 }
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group#location
 variable "location" {
-  type    = string
-  default = ""
+  type        = string
+  default     = ""
   description = "(Required) The Azure Region where the Resource Group should exist. Changing this forces a new Resource Group to be created."
 }
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group#tags
 variable "tags" {
-  type    = map
-  default = {}
+  type        = map(any)
+  default     = {}
   description = "(Optional) A mapping of tags which should be assigned to the Resource Group."
 }


### PR DESCRIPTION
### Description
When the module version changes, terraform tries to remove and recreate the resource group:
Plan: 1 to add, 0 to change, 1 to destroy.

This is a bad behavior as the resources inside the RG will be also removed!

With this PR we are leveraging the moved terraform statement, to avoid this behavior:

https://developer.hashicorp.com/terraform/language/moved
