### PR TITLE
Create cross account relationship

### DIFF
--- a/modules/aws-terraform-backend/FirestartrCloudFormationRole.yaml
+++ b/modules/aws-terraform-backend/FirestartrCloudFormationRole.yaml
@@ -1,0 +1,36 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Role to access Terraform backend in external AWS account.
+
+Parameters:
+  BackendAccountId:
+    Type: String
+    Description: The AWS account ID where the backend resources are stored.
+
+Resources:
+  CustomerTerraformRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: CustomerTerraformRole
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${BackendAccountId}:Administrator-firestartr-pro
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: AssumeBackendRolePolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: sts:AssumeRole
+                Resource: !Sub arn:aws:iam::${BackendAccountId}:Administrator-firestartr-pro/TerraformBackendAccessRole
+
+Outputs:
+  TerraformRoleName:
+    Value: !GetAtt CustomerTerraformRole
+    Description: Name of the IAM role created in the AWS account
+  TerraformRoleArn:
+    Value: !GetAtt CustomerTerraformRole.Arn
+    Description: ARN of the IAM role created in the AWS account

--- a/modules/aws-terraform-backend/README.md
+++ b/modules/aws-terraform-backend/README.md
@@ -16,22 +16,26 @@
 
 | Name | Type |
 |------|------|
-| [aws_s3_bucket.terraform_state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_versioning.terraform.state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
-| [aws_s3_bucket_server_side_encryption_configuration.terraform.state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
-| [aws_s3_bucket_public_access_block.terraform.state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_dynamodb_table.terraform.locks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/dynamodb_table) | resource |
+| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_versioning](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_public_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_dynamodb_table](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/dynamodb_table) | resource |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role)| resource |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
 
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| bucket_name | "Name of the S3 Bucket used for storing the Terraform state for the workspaces" | string | "" | Y |
+| bucket_name | "Name of the S3 Bucket used for storing the Terraform state for the workspaces" | string | -- | Y |
 | dynamodb_table_name | "Name of the locks DynamoDB table. Not needed if Terraform version is 1.11 or newer" | string | null | N |
-| tags | "Common tags for all resources" | string | "" | N |
+| tags | "Common tags for all resources" | map(string) | {} | N |
 | force_destroy | "Allow destroying the bucket even if it contains state" | boolean | false | N |
 | enable_versioning | "Enable versioning on the bucket" | boolean | true | N |
+| aws_account_id | "AWS Account ID that will assume the role to access the S3 bucket and the dynamodb table" | string | - | Y |
 
 
 ## Outputs

--- a/modules/aws-terraform-backend/create-cross-account-relationship.sh
+++ b/modules/aws-terraform-backend/create-cross-account-relationship.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+######################################################################################
+#                                                                                    #
+#       AUTHOR: Félix González - felix.gonzalez@prefapp.es                           #
+#                                                                                    #
+#  DESCRIPTION: Script which launches the necesary aws cli commands in order         #
+#               to create the cross account relationship for Terraform.              #
+#                                                                                    #
+#     REQUIRES: The following apps/commands must be installed an configured:         #
+#                   - aws cli: AWS command line utils, with a profile with the       #
+#                   - jq:      Command line JSON parser                              #
+#                                                                                    #
+#        USAGE: The following environment vars must be defined before launch:        #
+#                                                                                    #
+#               - AWS_REGION:   aws region for the deployment                        #
+#               - AWS_PROFILE:  aws cli profile name                                 #
+#               Then launch this script with ./create-cross-account-relationship.sh  #
+#                   or bash create-cross-account-relationship.sh                     #
+#                                                                                    #
+#  EXAMPLE: AWS_REGION=eu-west-1 AWS_PROFILE=default /                               #
+#           ./create-cross-account-relationship.sh                                   #
+#                                                                                    #
+######################################################################################
+
+# Exit on error...
+set -e
+
+# ------ Check mandatory enviroment variables ----------------------------------
+if ! command -v aws &> /dev/null; then
+    echo "aws cli must be installed"
+    exit 1
+fi
+
+if ! command -v jq &> /dev/null; then
+    echo "jq must be installed"
+    exit 1
+fi
+
+
+if [[ -z "${AWS_REGION}" ]]; then
+    echo "AWS_REGION env var not defined. We will use the default value 'eu-west-1'"
+    AWS_REGION="eu-west-1"
+fi
+
+if [[ -z "${AWS_PROFILE}" ]]; then
+    echo "AWS_PROFILE must be defined with the aws profile to use (or use 'default')"
+    exit 1
+fi
+
+# ---
+AWS_ACCOUNT_ID = $(aws sts get-caller-identity --profile ${AWS_PROFILE} --query "Account" --output text)
+
+
+# ------ Create resources using template ----------------------------------
+# BackendAccountId
+
+# Set stack name
+echo "Creating aws cross account relationship for ACCOUNT_ID=${AWS_ACCOUNT_ID}"
+# STACK_NAME="${PREFIX_LOWER}-tf-backend-stack"
+STACK_NAME="cross-account-relationship"
+# Let's create the stack with aws cli
+aws cloudformation deploy \
+    --stack-name ${STACK_NAME} \
+    --template-file $(pwd)/create-cross-account-relationship.yaml \
+    --parameter-overrides BackendAccountId=835677831763 \
+    --no-fail-on-empty-changeset \
+    --region=${AWS_REGION} \
+    --disable-rollback \
+    --profile ${AWS_PROFILE} \
+    --output json
+
+# ------ Wait for cloudformation to finish creation ---------------------------
+
+STATUS=$(aws cloudformation describe-stacks \
+                        --stack-name ${STACK_NAME} \
+                        --profile ${AWS_PROFILE}  \
+                        --output json \
+                        --region ${AWS_REGION} | \
+                        jq --arg stack "${STACK_NAME}" -c '.Stacks | .[] | select(.StackName == $stack) | .StackStatus' | \
+                        sed 's/"//g')
+
+while [ "$STATUS" == "CREATE_IN_PROGRESS" ]; do
+    sleep 5
+    STATUS=$(aws cloudformation describe-stacks \
+                            --stack-name ${STACK_NAME} \
+                            --profile ${AWS_PROFILE}  \
+                            --output json \
+                            --region ${AWS_REGION} | \
+                            jq --arg stack "${STACK_NAME}" -c '.Stacks | .[] | select(.StackName == $stack) | .StackStatus' | \
+                            sed 's/"//g')
+done
+
+echo "STATUS: ${STATUS}"
+
+if [ "$STATUS" != "CREATE_COMPLETE" ] && [ "$STATUS" != "UPDATE_COMPLETE" ] && [ "$STATUS" != "UPDATE_ROLLBACK_COMPLETE" ] ; then
+    echo "Stack creation failed, please clean the created resources..."
+    exit 1
+fi
+
+# Get cloudformation outputs
+STACK_OUTPUT=$(aws cloudformation describe-stacks \
+                            --stack-name ${STACK_NAME} \
+                            --profile ${AWS_PROFILE} \
+                            --output json \
+                            --region ${AWS_REGION} | jq --arg stack "${STACK_NAME}" -c '.Stacks | .[] | select(.StackName == $stack) |  .Outputs')
+
+# Capture "important" values
+ROLEARN=$(echo ${STACK_OUTPUT} | jq -c '.[] | select(.OutputKey == "TerraformRoleArn") | .OutputValue' | sed 's/\"//g')
+ROLENAME=$(echo ${STACK_OUTPUT} | jq -c '.[] | select(.OutputKey == "TerraformRoleName") | .OutputValue' | sed 's/\"//g')
+
+
+# ------ Show results data -----------------------------------------------------
+echo ""
+echo "DEPLOYED STACK ${STACK_NAME}:"
+echo ""
+echo "  - ROLE:           ${ROLENAME}"
+echo "  - ROLE ARN:       ${ROLEARN}"
+
+
+# ------ END --------------------------------------------------------------------

--- a/modules/aws-terraform-backend/variables.tf
+++ b/modules/aws-terraform-backend/variables.tf
@@ -26,3 +26,8 @@ variable "enable_versioning" {
   type        = bool
   default     = true
 }
+
+variable "aws_account_id" {
+  description = "AWS Account ID that will assume the role to access the S3 bucket and the dynamodb table"
+  type        = string
+}


### PR DESCRIPTION
Functionality to create cross account relationship:

- Allow an AWS account to assume administrative role in our shared Terraform backend