### PR TITLE
fix(aws-eks): remove extra depends-on from iam

### DIFF
--- a/modules/aws-eks/iam_ebs_csi_driver.tf
+++ b/modules/aws-eks/iam_ebs_csi_driver.tf
@@ -66,8 +66,6 @@ resource "aws_iam_role" "ebs_driver_policy" {
     ]
   })
 
-  depends_on = [module.eks]
-
 }
 
 


### PR DESCRIPTION
We removed an unnecessary `depends_on` statement from the `iam_ebs_csi_driver.tf` file and tested creating a new EKS cluster without any issues.
