### PR TITLE
fix: break cyclic check for bucket policy

### DIFF
--- a/modules/aws-secretsmanager-replication/cloudtrail.tf
+++ b/modules/aws-secretsmanager-replication/cloudtrail.tf
@@ -101,7 +101,7 @@ resource "aws_s3_bucket_policy" "cloudtrail" {
                   "aws:SourceAccount" = data.aws_caller_identity.current.account_id
                 }
               }, (
-                var.s3_bucket_name != "" && var.cloudtrail_name != "" ? {
+                var.s3_bucket_name != "" && var.cloudtrail_name != "" && var.cloudtrail_arn != "" ? {
                   ArnLike = {
                     "aws:SourceArn" = local.cloudtrail_arn
                   }
@@ -120,7 +120,7 @@ resource "aws_s3_bucket_policy" "cloudtrail" {
                   "aws:SourceAccount" = data.aws_caller_identity.current.account_id
                 }
               }, (
-                var.s3_bucket_name != "" && var.cloudtrail_name != "" ? {
+                var.s3_bucket_name != "" && var.cloudtrail_name != "" && var.cloudtrail_arn != "" ? {
                   ArnLike = {
                     "aws:SourceArn" = local.cloudtrail_arn
                   }
@@ -148,7 +148,7 @@ resource "aws_s3_bucket_policy" "cloudtrail" {
               "aws:SourceAccount" = data.aws_caller_identity.current.account_id
             }
           }, (
-            var.s3_bucket_name != "" && var.cloudtrail_name != "" ? {
+            var.s3_bucket_name != "" && var.cloudtrail_name != "" && var.cloudtrail_arn != "" ? {
               ArnLike = {
                 "aws:SourceArn" = local.cloudtrail_arn
               }
@@ -167,7 +167,7 @@ resource "aws_s3_bucket_policy" "cloudtrail" {
               "aws:SourceAccount" = data.aws_caller_identity.current.account_id
             }
           }, (
-            var.s3_bucket_name != "" && var.cloudtrail_name != "" ? {
+            var.s3_bucket_name != "" && var.cloudtrail_name != "" && var.cloudtrail_arn != "" ? {
               ArnLike = {
                 "aws:SourceArn" = local.cloudtrail_arn
               }


### PR DESCRIPTION
```
  > 13-02-2026 12:07:15 [INFO] Terraform initialization completed in '/tmp//home/runner/work/infra/infra/accounts/prefapp-beginners/dev/35-test-module-secretsmanager-replication'
  > 13-02-2026 12:07:15 [INFO] Running Terraform action: plan on module '35-test-module-secretsmanager-replication' in '/tmp//home/runner/work/infra/infra/accounts/prefapp-beginners/dev/35-test-module-secretsmanager-replication'
  > 13-02-2026 12:07:15 [INFO] terraform -chdir='/tmp//home/runner/work/infra/infra/accounts/prefapp-beginners/dev/35-test-module-secretsmanager-replication' plan                     -lock=false                     -input=false                     -var-file='/home/runner/work/infra/infra/accounts/prefapp-beginners/dev/35-test-module-secretsmanager-replication/terraform.tfvars'                      
  ╷
  │ Error: Cycle: aws_s3_bucket_policy.cloudtrail, aws_cloudtrail.secrets_management_events, local.cloudtrail_arn (expand)
  │ 
  │ 
  ╵
  Error: Terraform exited with code 1.
  Script failed.
  https://github.com/firestartr-pro/infra/pull/170#issuecomment-3896841251
  Error: Failed to run 'terrafire plan' command for environment dev and module 35-test-module-secretsmanager-replication
  ❌ **Terraform plan FAILED** for tenant `prefapp-beginners`. Please check the workflow logs for details.
  https://github.com/firestartr-pro/infra/pull/170#issuecomment-3896841320
  Error: plan failed in module(s): '35-test-module-secretsmanager-replication'.
  Error: Process completed with exit code 1.
```