### PR TITLE
fix(aws-secretsmanager-replication): capture InvalidParameterException on secret creation

### DIFF
--- a/modules/aws-secretsmanager-replication/src/common/replication.py
+++ b/modules/aws-secretsmanager-replication/src/common/replication.py
@@ -148,7 +148,15 @@ def replicate_secret(secret_id: str, config, get_sm_client=None, skip_missing_cu
                 # Si no hay KmsKeyId, AWS managed
                 try:
                     sm_dest.create_secret(**create_args)
-                except sm_dest.exceptions.ResourceExistsException:
+                except Exception as e:
+                    # Check if it's a "secret already exists" error
+                    # AWS may return either ResourceExistsException or InvalidParameterException
+                    error_code = getattr(e, 'response', {}).get('Error', {}).get('Code', '') if hasattr(e, 'response') else ''
+                    error_message = str(e)
+
+                    if not ('ResourceExistsException' in error_code or 'InvalidParameterException' in error_code or 'already exists' in error_message):
+                        raise
+
                     log(
                         "warning",
                         "Destination secret already exists during creation, continuing with update",


### PR DESCRIPTION
### Log: 

```[ERROR] InvalidParameterException: An error occurred (InvalidParameterException) when calling the CreateSecret operation: A secret with the same name already exists. Traceback (most recent call last):   File "/var/task/handler.py", line 55, in lambda_handler     replicate_secret(secret_id, config, skip_missing_current=True)   File "/var/task/replication.py", line 150, in replicate_secret     sm_dest.create_secret(**create_args)   File "/var/lang/lib/python3.12/site-packages/botocore/client.py", line 602, in _api_call     return self._make_api_call(operation_name, kwargs)   File "/var/lang/lib/python3.12/site-packages/botocore/context.py", line 123, in wrapper     return func(*args, **kwargs)   File "/var/lang/lib/python3.12/site-packages/botocore/client.py", line 1078, in _make_api_call     raise error_class(parsed_response, operation_name) ```

### Proposed change: 

Capture InvalidParameterException alongside ResourceExistsException when a new secret is created in destination, and update the secret in either of these cases