### PR TITLE
fix(aws-secretsmanager-replication): fix origin region name prefix

### DIFF
--- a/modules/aws-secretsmanager-replication/README.md
+++ b/modules/aws-secretsmanager-replication/README.md
@@ -51,7 +51,7 @@ The Lambda determines:
 - from the `secret_id` parameter (manual mode),
 - or from `list_secrets()` (full sync mode).
 
-The **destination secret name is always the same as the source secret name**, simplifying configuration and IAM permissions.
+By default, the **destination secret name is the same as the source secret name**. If `add_region_prefix_to_name = true`, the destination secret name is prefixed with the **source region** (for example, `eu-west-1-mysecret`) to preserve origin traceability.
 
 ### Destination Configuration Format
 
@@ -244,7 +244,7 @@ The destination account must have an IAM role that the replication Lambda can as
 
 Starting from version X.X, the module implements the following improvements for cross-region secret replication:
 
-- Replicated secrets are automatically renamed with the region code as a prefix (e.g., `eu-west-3-mysecret`).
+- When enabled via `add_region_prefix_to_name`, replicated secrets are renamed with the **source region** code as a prefix (e.g., `eu-west-3-mysecret`).
 - Replicated secrets include additional tags:
   - `origin-account`: the source AWS account.
   - `origin-region`: the source AWS region.
@@ -296,7 +296,7 @@ This allows secrets with the same name from different regions to be copied into 
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_add_region_prefix_to_name"></a> [add\_region\_prefix\_to\_name](#input\_add\_region\_prefix\_to\_name) | If true, the destination secret name will be prefixed with the region (e.g., "us-east-1-mysecret").<br/>If false, the original name is used. Default: false.<br/>This helps avoid colisiones si replicas secretos con el mismo nombre desde varias regiones. | `bool` | `false` | no |
+| <a name="input_add_region_prefix_to_name"></a> [add\_region\_prefix\_to\_name](#input\_add\_region\_prefix\_to\_name) | If true, the destination secret name will be prefixed with the source region (e.g., "us-east-1-mysecret").<br/>If false, the original name is used. Default: false.<br/>This helps avoid colisiones si replicas secretos con el mismo nombre desde varias regiones. | `bool` | `false` | no |
 | <a name="input_allow_auto_create_cloudtrail_bucket"></a> [allow\_auto\_create\_cloudtrail\_bucket](#input\_allow\_auto\_create\_cloudtrail\_bucket) | Fallback mode. If true, and s3\_bucket\_arn is empty, the module may create a dedicated S3 bucket for CloudTrail logs. Default is false to enforce enterprise-style reuse of an existing centralized bucket. | `bool` | `false` | no |
 | <a name="input_allowed_assume_roles"></a> [allowed\_assume\_roles](#input\_allowed\_assume\_roles) | List of IAM roles the Lambda can assume for cross-account replication | `list(string)` | n/a | yes |
 | <a name="input_cloudtrail_arn"></a> [cloudtrail\_arn](#input\_cloudtrail\_arn) | (Optional) ARN of an existing CloudTrail. If omitted and eventbridge\_enabled is true, the module creates a dedicated trail. | `string` | `""` | no |

--- a/modules/aws-secretsmanager-replication/docs/header.md
+++ b/modules/aws-secretsmanager-replication/docs/header.md
@@ -50,7 +50,7 @@ The Lambda determines:
 - from the `secret_id` parameter (manual mode),
 - or from `list_secrets()` (full sync mode).
 
-The **destination secret name is always the same as the source secret name**, simplifying configuration and IAM permissions.
+By default, the **destination secret name is the same as the source secret name**. If `add_region_prefix_to_name = true`, the destination secret name is prefixed with the **source region** (for example, `eu-west-1-mysecret`) to preserve origin traceability.
 
 ### Destination Configuration Format
 
@@ -244,7 +244,7 @@ The destination account must have an IAM role that the replication Lambda can as
 
 Starting from version X.X, the module implements the following improvements for cross-region secret replication:
 
-- Replicated secrets are automatically renamed with the region code as a prefix (e.g., `eu-west-3-mysecret`).
+- When enabled via `add_region_prefix_to_name`, replicated secrets are renamed with the **source region** code as a prefix (e.g., `eu-west-3-mysecret`).
 - Replicated secrets include additional tags:
   - `origin-account`: the source AWS account.
   - `origin-region`: the source AWS region.

--- a/modules/aws-secretsmanager-replication/src/common/replication.py
+++ b/modules/aws-secretsmanager-replication/src/common/replication.py
@@ -91,6 +91,7 @@ def replicate_secret(secret_id: str, config, get_sm_client=None, skip_missing_cu
 
 
     add_region_prefix = getattr(config, "add_region_prefix_to_name", False)
+    source_region = str(config.source_region)
 
     for account_id, dest in config.destinations.items():
         log("info", "Processing destination account", account_id=account_id)
@@ -98,9 +99,9 @@ def replicate_secret(secret_id: str, config, get_sm_client=None, skip_missing_cu
         for region_name, region_cfg in dest.regions.items():
             log("info", "Replicating to region", account_id=account_id, region=region_name)
 
-            # Destination secret name: region-prefixed or original, max 512 chars
+            # Destination secret name: source-region-prefixed or original, max 512 chars
             if add_region_prefix:
-                raw_dest_name = f"{region_name}-{secret_metadata['Name']}"
+                raw_dest_name = f"{source_region}-{secret_metadata['Name']}"
             else:
                 raw_dest_name = secret_metadata['Name']
             dest_name = raw_dest_name[:512]
@@ -114,7 +115,7 @@ def replicate_secret(secret_id: str, config, get_sm_client=None, skip_missing_cu
             # Build replication tags
             replication_tags = [
                 {"Key": "origin-account", "Value": str(config.source_account)},
-                {"Key": "origin-region", "Value": str(region_name)},
+                {"Key": "origin-region", "Value": source_region},
                 {"Key": "latest-version", "Value": str(secret_response.get("VersionId", ""))}
             ]
             # Merge original tags if enabled, avoiding duplicates

--- a/modules/aws-secretsmanager-replication/variables.tf
+++ b/modules/aws-secretsmanager-replication/variables.tf
@@ -37,7 +37,7 @@ variable "destinations_json" {
 
 variable "add_region_prefix_to_name" {
   description = <<-EOT
-If true, the destination secret name will be prefixed with the region (e.g., "us-east-1-mysecret").
+If true, the destination secret name will be prefixed with the source region (e.g., "us-east-1-mysecret").
 If false, the original name is used. Default: false.
 This helps avoid colisiones si replicas secretos con el mismo nombre desde varias regiones.
 EOT

--- a/specs/aws-secretsmanager-replication/001-fix-origin-region-prefix/plan.md
+++ b/specs/aws-secretsmanager-replication/001-fix-origin-region-prefix/plan.md
@@ -1,0 +1,12 @@
+# Plan: Fix origin-region naming semantics in aws-secretsmanager-replication
+
+**Spec:** `spec.md`
+**Module:** `modules/aws-secretsmanager-replication`
+
+## Steps
+
+1. Update replication code so prefixed destination names use source region instead of destination region.
+2. Update replication metadata tag `origin-region` to use source region.
+3. Update docs in `docs/header.md` and variable description to describe source-region prefix behavior.
+4. Regenerate `README.md` with `terraform-docs .` from module directory.
+5. Run focused validation checks for modified code/docs and finalize tasks.

--- a/specs/aws-secretsmanager-replication/001-fix-origin-region-prefix/spec.md
+++ b/specs/aws-secretsmanager-replication/001-fix-origin-region-prefix/spec.md
@@ -1,0 +1,37 @@
+# Specification: Fix origin-region naming semantics in aws-secretsmanager-replication
+
+**Date:** 2026-06-09
+**Module:** `modules/aws-secretsmanager-replication`
+
+## Problem
+
+The current replication logic prefixes destination secret names with the destination region when `add_region_prefix_to_name = true`. For disaster-recovery traceability, the prefix must represent the source region (where the secret originated).
+
+Additionally, the `origin-region` replication tag is currently populated with destination region values, which is semantically incorrect.
+
+## Goal
+
+Ensure replicated secrets in destination accounts/regions identify their source correctly by:
+
+- Prefixing names with source region when the prefix feature is enabled.
+- Setting `origin-region` tag to source region.
+- Updating module documentation to match behavior.
+
+## Scope
+
+- Update Python replication logic in `modules/aws-secretsmanager-replication/src/common/replication.py`.
+- Update module docs text (`docs/header.md`, and generated `README.md`) describing prefix behavior.
+- Keep behavior unchanged when `add_region_prefix_to_name = false`.
+
+## Out of Scope
+
+- Any replication direction redesign (failback orchestration, bidirectional sync).
+- IAM/KMS policy model redesign.
+- Any `CHANGELOG.md` modification.
+
+## Acceptance Criteria
+
+- With `add_region_prefix_to_name = true`, destination secret name uses `<source-region>-<source-secret-name>`.
+- `origin-region` tag stores the source region value.
+- Documentation clearly states source-region prefix semantics and remains consistent with implementation.
+- `README.md` is regenerated using `terraform-docs`.

--- a/specs/aws-secretsmanager-replication/001-fix-origin-region-prefix/tasks.md
+++ b/specs/aws-secretsmanager-replication/001-fix-origin-region-prefix/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: Fix origin-region naming semantics in aws-secretsmanager-replication
+
+**Module:** `aws-secretsmanager-replication`
+**Spec:** `spec.md`
+**Plan:** `plan.md`
+
+## Tasks
+
+- [x] 1. Create `spec.md`, `plan.md`, and `tasks.md` for this change.
+- [x] 2. Update replication code to use source region in prefixed destination secret names.
+- [x] 3. Update replication tags so `origin-region` is the source region.
+- [x] 4. Update module docs text for `add_region_prefix_to_name` and cross-region behavior.
+- [x] 5. Regenerate `README.md` using `terraform-docs` (without manual README edits).
+- [x] 6. Run targeted validation checks and complete final review.
+
+## Validation Notes
+
+- `terraform-docs .` executed successfully in module directory.
+- `terraform fmt -check variables.tf` passed for the touched Terraform file.
+- Full-module `terraform fmt -check` reports `lambda.tf` as not formatted (pre-existing, unrelated to this change).


### PR DESCRIPTION
## Motivation

When replicating a secret, If the "add_region_prefix_to_name" is present we add the region name as a prefix. But we have observed that the region name added is that of the destination account, not of the origin account.

## Intended behavior

In order to correctly detect the origin of the secret, the origin region is what must be used.