### PR TITLE
fix: enable share properties

### DIFF
--- a/modules/azure-sa/main.tf
+++ b/modules/azure-sa/main.tf
@@ -57,6 +57,17 @@ resource "azurerm_storage_account" "this" {
       }
     }
   }
+  dynamic "share_properties" {
+    for_each = var.storage_account.share_properties != null ? [var.storage_account.share_properties] : []
+    content {
+      dynamic "retention_policy" {
+        for_each = share_properties.value.retention_policy != null ? [share_properties.value.retention_policy] : []
+        content {
+          days = lookup(retention_policy.value, "days", null)
+        }
+      }
+    }
+  }
   dynamic "identity" {
     for_each = var.storage_account.identity != null ? [var.storage_account.identity] : []
     content {

--- a/modules/azure-sa/variables.tf
+++ b/modules/azure-sa/variables.tf
@@ -69,6 +69,11 @@ variable "storage_account" {
         days = optional(number)
       }))
     }))
+    share_properties = optional(object({
+      retention_policy = optional(object({
+        days = optional(number)
+      }))
+    }))
   })
 
   # Validation block for `account_kind`
@@ -133,6 +138,20 @@ variable "storage_account" {
       )
     )
     error_message = "restore_policy.days must be between 1 and 365, and less than delete_retention_policy.days. Additionally, delete_retention_policy must be set, and versioning_enabled and change_feed_enabled must be true."
+  }
+
+  # Validation block for `share_properties.retention_policy`
+  validation {
+    condition = (
+      var.storage_account.share_properties == null ? true : (
+        var.storage_account.share_properties.retention_policy == null ? true : (
+          var.storage_account.share_properties.retention_policy.days != null &&
+          var.storage_account.share_properties.retention_policy.days >= 1 &&
+          var.storage_account.share_properties.retention_policy.days <= 365
+        )
+      )
+    )
+    error_message = "share_properties.retention_policy.days must be between 1 and 365."
   }
 }
 


### PR DESCRIPTION
### Summary
This PR adds support for configuring Azure File Share soft delete retention through the storage account module and applies it to the GISS storage account claim.

### What Changed

- Added storage_account.share_properties.retention_policy.days as an optional module input.
- Wired share_properties.retention_policy into the azurerm_storage_account resource.
- Added validation to ensure retention days are between 1 and 365.
- Updated the GISS claim to set:
  - Blob soft delete: 7 days
  - Container soft delete: 7 days
  - Point-in-time restore: 6 days (required to be lower than blob delete retention)
  - File share soft delete: 7 days

### Notes

- No SMB-specific share_properties.smb settings were introduced.
- No share_properties.cors_rule configuration was introduced.
- Existing share-level enabled_protocol: "SMB" examples remain unrelated to share_properties.smb.

### Expected Impact

- Enables consistent 7-day soft delete retention for blobs, containers, and file shares in the target environment.
- Keeps PITR enabled and compliant with module/provider constraints.
